### PR TITLE
Shared Variable Resolve Read Fix

### DIFF
--- a/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/RequestSchema.java
+++ b/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/RequestSchema.java
@@ -4,15 +4,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.rule.generic.token.schema.cert.SSLContextSchema;
 import com.networknt.rule.generic.token.schema.jwt.JWTSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.util.HashMap;
 import java.util.Map;
 
 
 @JsonIgnoreProperties(value={ "sslContext", "httpRequest", "httpClient" }, allowGetters=true)
 public class RequestSchema extends SharedVariableRead {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestSchema.class);
+
     @JsonProperty("url")
     private String url;
     @JsonProperty("headers")
@@ -99,9 +105,27 @@ public class RequestSchema extends SharedVariableRead {
         this.sslContext = sslContext;
     }
 
-    @Override
-    public void writeSchemaFromSharedVariables(final SharedVariableSchema sharedVariableSchema) {
-        SharedVariableRead.updateMapFromSharedVariables(this.headers, sharedVariableSchema);
-        SharedVariableRead.updateMapFromSharedVariables(this.body, sharedVariableSchema);
+    public Map<String, String> getResolvedHeaders(final SharedVariableSchema sharedVariableSchema) {
+
+        if (this.headers == null) {
+            LOG.trace("No headers defined in request schema.");
+            return new HashMap<>();
+        }
+
+        final var resolvedHeaders = new HashMap<>(this.headers);
+        SharedVariableRead.updateMapFromSharedVariables(resolvedHeaders, sharedVariableSchema);
+        return resolvedHeaders;
+    }
+
+    public Map<String, String> getResolvedBody(final SharedVariableSchema sharedVariableSchema) {
+
+        if (this.body == null) {
+            LOG.trace("No body defined in request schema.");
+            return  new HashMap<>();
+        }
+
+        final var resolvedBody = new HashMap<>(this.body);
+        SharedVariableRead.updateMapFromSharedVariables(resolvedBody, sharedVariableSchema);
+        return resolvedBody;
     }
 }

--- a/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/SharedVariableRead.java
+++ b/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/SharedVariableRead.java
@@ -17,8 +17,6 @@ public abstract class SharedVariableRead extends SharedVariableSchema {
 
     private static final Logger LOG = LoggerFactory.getLogger(SharedVariableRead.class);
 
-    public abstract void writeSchemaFromSharedVariables(final SharedVariableSchema sharedVariableSchema);
-
     protected static void updateMapFromSharedVariables(final Map<String, String> map, final SharedVariableSchema sharedVariableSchema) {
         if (map == null)
             return;

--- a/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/SharedVariableWrite.java
+++ b/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/SharedVariableWrite.java
@@ -17,6 +17,7 @@ public abstract class SharedVariableWrite extends SharedVariableSchema {
     private static final Logger LOG = LoggerFactory.getLogger(SharedVariableWrite.class);
 
     public static void writeToSharedVariables(final SharedVariableSchema sharedVariableSchema, final Map<String, Object> sourceData, final List<SourceSchema.SourceDestinationDefinition> sourceDestinationMapping) {
+
         if (sourceDestinationMapping == null || sourceDestinationMapping.isEmpty() || sourceData == null || sourceData.isEmpty())
             return;
 
@@ -28,49 +29,66 @@ public abstract class SharedVariableWrite extends SharedVariableSchema {
         }
 
         for (final var sourceEntry : sourceDestinationMapping) {
+
             if (sourceData.get(sourceEntry.getSource()) instanceof String) {
-                final var value = (String) sourceData.get(sourceEntry.getSource());
+                final var sharedVariableValue = (String) sourceData.get(sourceEntry.getSource());
                 final var matcher = VARIABLE_PATTERN.matcher(sourceEntry.getDestination());
 
                 if (matcher.find()) {
-                    final var variable = matcher.group(1);
-                    final var searchArr = variable.split("\\.");
-                    if (searchArr.length == 2) {
-                        pushToSharedVariable(sharedVariableSchema, beaninfo, searchArr[1], value);
-                    }
+                    final var variableName = matcher.group(1);
+
+                    /* split prefix and suffix by the "." */
+                    final var variableNameArray = variableName.split("\\.");
+
+                    if (variableNameArray.length == 2)
+                        pushToSharedVariable(sharedVariableSchema, beaninfo, variableNameArray[1], sharedVariableValue);
+
+                    else throw new IllegalArgumentException("Invalid variable name provided: " + variableName);
+
                 }
             }
         }
     }
 
     private static void pushToSharedVariable(final SharedVariableSchema sharedVariableSchema, final BeanInfo beanInfo, final String sharedVariableName, final String newSharedVariableValue) {
-        PropertyDescriptor[] pds = beanInfo.getPropertyDescriptors();
+
+        LOG.trace("Attempting to set variable '{}' with the new value of '{}'", sharedVariableName, newSharedVariableValue);
+
+        PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
         Method setterMethod;
 
-        for (PropertyDescriptor pd : pds) {
+        LOG.trace("Starting search for {} setter method via BeanInfo.", sharedVariableName);
+        for (PropertyDescriptor descriptor : propertyDescriptors) {
 
-            if (pd.getName().equalsIgnoreCase(sharedVariableName)) {
-                setterMethod = pd.getWriteMethod(); // For Setter Method
+            if (descriptor.getName().equalsIgnoreCase(sharedVariableName)) {
+                setterMethod = descriptor.getWriteMethod(); // For Setter Method
 
                 if (setterMethod != null) {
+
+                    LOG.trace("Found setter method '{}'", setterMethod.getName());
+
                     try {
                         final var argTypes = setterMethod.getParameterTypes();
 
-                        if (argTypes.length != 1)
+                        if (argTypes.length != 1) {
+                            LOG.error("Setter method '{}' has {} parameters instead of 1", setterMethod.getName(), argTypes.length);
                             continue;
+                        }
 
                         final var onlyArg = argTypes[0];
 
                         /* string argument setter */
                         if (onlyArg == String.class) {
+                            LOG.trace("Setting '{}' with a new string value of '{}'", sharedVariableName, newSharedVariableValue);
                             setterMethod.invoke(sharedVariableSchema, newSharedVariableValue);
-
                         /* char array argument setter */
                         } else if (onlyArg.getName().equalsIgnoreCase("[C")) {
+                            LOG.trace("Setting '{}' with a new char array value of '{}'", sharedVariableName, newSharedVariableValue);
                             setterMethod.invoke(sharedVariableSchema, newSharedVariableValue.toCharArray());
 
                         /* long argument setter */
                         } else if (onlyArg.getName().equalsIgnoreCase("long")) {
+                            LOG.trace("Setting '{}' with a new long value of '{}'", sharedVariableName, newSharedVariableValue);
                             setterMethod.invoke(sharedVariableSchema, Long.parseLong(newSharedVariableValue));
 
                         } else {

--- a/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/UpdateSchema.java
+++ b/token-transformer/src/main/java/com/networknt/rule/generic/token/schema/UpdateSchema.java
@@ -4,10 +4,15 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class UpdateSchema extends SharedVariableRead {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateSchema.class);
 
     public enum UpdateDirection {
 
@@ -53,14 +58,27 @@ public class UpdateSchema extends SharedVariableRead {
         return updateExpirationFromTtl;
     }
 
-    /**
-     * Takes in a sharedVariableSchema object and populates the header and body fields that use the !ref keyword.
-     *
-     * @param sharedVariableSchema - the provided SharedVariableSchema containing the data.
-     */
-    @Override
-    public void writeSchemaFromSharedVariables(final SharedVariableSchema sharedVariableSchema) {
-        SharedVariableRead.updateMapFromSharedVariables(this.headers, sharedVariableSchema);
-        SharedVariableRead.updateMapFromSharedVariables(this.body, sharedVariableSchema);
+    public Map<String, String> getResolvedHeaders(final SharedVariableSchema sharedVariableSchema) {
+
+        if (this.headers == null) {
+            LOG.trace("No headers defined in update schema.");
+            return  new HashMap<>();
+        }
+
+        final var resolvedHeaders = new HashMap<>(this.headers);
+        SharedVariableRead.updateMapFromSharedVariables(resolvedHeaders, sharedVariableSchema);
+        return resolvedHeaders;
+    }
+
+    public Map<String, String> getResolvedBody(final SharedVariableSchema sharedVariableSchema) {
+
+        if (this.body == null) {
+            LOG.trace("No body defined in update schema.");
+            return  new HashMap<>();
+        }
+
+        final var resolvedBody = new HashMap<>(this.body);
+        SharedVariableRead.updateMapFromSharedVariables(resolvedBody, sharedVariableSchema);
+        return resolvedBody;
     }
 }

--- a/token-transformer/src/test/java/com/networknt/rule/generic/token/TokenTransformerActionTest.java
+++ b/token-transformer/src/test/java/com/networknt/rule/generic/token/TokenTransformerActionTest.java
@@ -32,8 +32,7 @@ public class TokenTransformerActionTest {
     }
 
     @Test
-    public void updateTest() {
-
+    public void updateHeaderTest() {
         /* test access token */
         var testSharedVariable = new SharedVariableSchema();
         testSharedVariable.setAccessToken("abc123");
@@ -45,9 +44,7 @@ public class TokenTransformerActionTest {
         testUpdateSchema.setHeaders(myUpdateHeaders);
 
         /* testing update */
-        testUpdateSchema.writeSchemaFromSharedVariables(testSharedVariable);
-
-        Assert.assertEquals("Bearer abc123", testUpdateSchema.getHeaders().get("Authorization"));
+        Assert.assertEquals("Bearer abc123", testUpdateSchema.getResolvedHeaders(testSharedVariable).get("Authorization"));
 
     }
 
@@ -168,5 +165,25 @@ public class TokenTransformerActionTest {
         final var expirationSchemaTtlUnit = schema.getTokenSource().getExpirationSchema().getTtlUnit();
 
         Assert.assertEquals(1, expirationSchemaTtlUnit.millisToUnit(60000));
+    }
+
+    @Test
+    public void resolvedVariableCachingTest() {
+        /* test access token */
+        var testSharedVariable = new SharedVariableSchema();
+        testSharedVariable.setAccessToken("abc123");
+
+        /* create test update schema */
+        var testUpdateSchema = new UpdateSchema();
+        Map<String, String> myUpdateHeaders = new HashMap<>();
+        myUpdateHeaders.put("Authorization", "Bearer !ref(sharedVariables.accessToken)");
+        testUpdateSchema.setHeaders(myUpdateHeaders);
+
+        /* testing update */
+        Assert.assertEquals("Bearer abc123", testUpdateSchema.getResolvedHeaders(testSharedVariable).get("Authorization"));
+
+        /* testing second update */
+        testSharedVariable.setAccessToken("abc124");
+        Assert.assertEquals("Bearer abc124", testUpdateSchema.getResolvedHeaders(testSharedVariable).get("Authorization"));
     }
 }


### PR DESCRIPTION
- Fixed issue by resolving variables each call instead of overriding the original configuration.
- This means new values will be used when called in a scenario where the request data needs to change (i.e. token expires and a new request needs to be constructed.)